### PR TITLE
修复代理产物手动发布入口

### DIFF
--- a/.github/workflows/publish-proxies.yml
+++ b/.github/workflows/publish-proxies.yml
@@ -2,8 +2,6 @@ name: Publish Proxy Artifacts
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -162,8 +162,8 @@ cython_debug/
 
 # Go build outputs
 bin/
-sky-socks5
-sky-socks5.exe
+/sky-socks5
+/sky-socks5.exe
 
 # Generated proxy artifacts
 generated/

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ go run ./cmd/sky-socks5 -h
 ## GitHub automation
 
 - **Go CI** runs `go test ./...`.
-- **Publish Proxy Artifacts** runs the Go CLI on a schedule or by manual dispatch and uploads the generated outputs.
+- **Publish Proxy Artifacts** runs the Go CLI by manual dispatch and uploads the generated outputs.
 - **Release** builds archives from `./cmd/sky-socks5` for tagged releases.
 
 ## Deprecated Python scripts

--- a/cmd/sky-socks5/main.go
+++ b/cmd/sky-socks5/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/BlueSkyXN/SKY-Socks5/internal/pipeline"
+)
+
+func main() {
+	if err := pipeline.RunCLI(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## 背景

`Publish Proxy Artifacts` 最近定时运行失败，日志显示 `go run ./cmd/sky-socks5` 找不到 `cmd/sky-socks5` 目录。原因是 `.gitignore` 中的 `sky-socks5` 规则误忽略了 `cmd/sky-socks5/`，导致 CLI 入口文件没有被提交到仓库。

同时当前不需要每天自动运行代理产物生成任务，因此取消该 workflow 的 `schedule` 触发，只保留手动触发。

## 变更

- 将 `.gitignore` 的 Go 二进制忽略规则限定到仓库根目录，避免误忽略 `cmd/sky-socks5/`。
- 提交 `cmd/sky-socks5/main.go`，恢复 README、Release workflow 和 Publish workflow 使用的标准 CLI 入口。
- 移除 `Publish Proxy Artifacts` 的每日 cron，仅保留 `workflow_dispatch` 手动运行。
- 更新 README 中 GitHub automation 描述，说明代理产物发布改为手动触发。

## 验证

- `go test ./...`
- `go build -o /tmp/sky-socks5-test ./cmd/sky-socks5`
- `go run ./cmd/sky-socks5 -h`