### PR TITLE
docs: add Codex AGENTS.md navigation cards

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,28 @@
+# .github navigation card
+
+`.github/` is the repository control plane for ownership and automation. Read this card before changing `CODEOWNERS`, workflow permissions, triggers, branch-gate assumptions, or automation policy. Key files: `CODEOWNERS`, `workflows/ci.yml`, `workflows/build.yml`, `workflows/cd.yml`.
+
+## Why this is high-risk
+
+- Workflow changes can alter CI, build artifacts, and live proxy validation.
+- Permission changes affect the repository security boundary.
+- `CODEOWNERS` changes affect review routing for protected paths.
+
+## Required before changes
+
+- Read the specific workflow file you are changing.
+- For workflow edits, also read `.github/workflows/AGENTS.md`.
+- Keep default workflow permissions at `contents: read` unless the user asks for broader behavior and the change explains why.
+- Preserve CODEOWNERS coverage for `.github/` unless the user explicitly changes ownership policy.
+
+## Do not
+
+- Do not add release publishing, write permissions, or token use without explicit user approval.
+- Do not remove manual `workflow_dispatch` CD controls without a clear replacement.
+- Do not hide network-heavy validation in ordinary CI.
+
+## Validation
+
+- `actionlint .github/workflows/*.yml` if `actionlint` is installed.
+- `go test ./...` for CI-related changes.
+- CD behavior requires GitHub Actions network conditions and cannot be fully proven by local runs.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,31 @@
+# .github/workflows navigation card
+
+`.github/workflows/` contains GitHub Actions workflows for program tests, cross-platform build artifacts, and live proxy validation. Read this card after `.github/AGENTS.md` before editing any workflow YAML. Key files: `ci.yml`, `build.yml`, `cd.yml`.
+
+## Local invariants
+
+- `ci.yml` runs Go program tests only with `go test ./...`.
+- `build.yml` creates Linux, macOS, and Windows archives as workflow artifacts; it does not publish GitHub Releases.
+- `cd.yml` is manually dispatched proxy validation in the GitHub Actions network environment and uploads `generated/` artifacts.
+- CD concurrency is `cd-proxy-validation` with `cancel-in-progress: true`.
+- Workflow job summaries are bilingual and document scope, inputs, totals, and artifact fields.
+
+## Local rules
+
+- Keep `actions/setup-go` pointed at `go.mod` for the Go version.
+- If report fields change, update the CD summary parser and `docs/result-fields.md` together.
+- If source input behavior changes, update CD inputs and `docs/sources.md` together.
+- Treat shell blocks as production automation: use explicit error handling and avoid silently ignoring failures.
+
+## Do not
+
+- Do not move live proxy validation into normal push/pull_request CI.
+- Do not publish releases from `build.yml` unless the user asks for release automation.
+- Do not broaden permissions beyond `contents: read` without a concrete workflow need.
+- Do not remove CD artifact upload unless the result-delivery path is replaced.
+
+## Validation
+
+- `actionlint .github/workflows/*.yml` if installed.
+- `go test ./...` when workflow changes affect CI commands.
+- CD end-to-end validation must be confirmed in GitHub Actions; local `go run . -output-dir generated` is only a smoke check and requires network.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# Repository agent instructions
+
+## Purpose
+
+SKY-Socks5 is a small Go CLI for collecting public SOCKS5 proxy lists, parsing and normalizing `host:port` candidates, validating reachability through a probe URL, and writing deterministic TXT, CSV, and JSON artifacts.
+
+Public proxies are noisy and untrusted. Treat local runs as development evidence only; the repository's live proxy validation signal belongs to the GitHub Actions CD workflow.
+
+## Codex startup behavior
+
+- Codex normally starts from the repository root. This file is the root router for that workflow.
+- Subdirectory `AGENTS.md` files are local navigation cards. They are not guaranteed to be in startup context when Codex starts at the root.
+- Before editing a path with `Local AGENTS.md = Yes` in the directory map, read the local card with `cat <path>/AGENTS.md`.
+- If multiple nested cards apply, read them from shallow to deep before making changes.
+- If a future `AGENTS.override.md` appears in a target directory, stop and ask the user how to handle that override before editing ordinary `AGENTS.md` there.
+
+## Directory map
+
+| Path | Responsibility | Local AGENTS.md | Read when |
+|---|---|---:|---|
+| `main.go` | CLI process entrypoint; delegates to `app/pipeline`. | No | Read before changing process exit, stdout/stderr behavior, or CLI startup. |
+| `go.mod` | Go module declaration; currently Go 1.22 with no third-party requirements. | No | Read before changing Go version or adding dependencies. |
+| `app/` | Application packages for config, source loading, fetch, proxy parsing, validation, output, reporting, and orchestration. | Yes | Read before any Go code change under `app/`, especially package boundary changes. |
+| `app/config/` | CLI flags, defaults, aliases, URL checks, output path resolution. | Yes | Read before changing flags, defaults, validation, output paths, or help text. |
+| `app/source/` | Loads source URLs from newline-delimited files. | Yes | Read before changing source file parsing, comment handling, or empty-source behavior. |
+| `app/fetch/` | Concurrently downloads upstream source lists and records HTTP/source metadata. | Yes | Read before changing fetch concurrency, proxy use, timeout behavior, HTTP status handling, or response line parsing. |
+| `app/proxy/` | Parses, normalizes, deduplicates, validates, and sorts SOCKS5 candidate addresses. | Yes | Read before changing accepted input formats, scheme policy, metadata extraction, IPv6 handling, or sort order. |
+| `app/validate/` | Tests unique SOCKS5 proxies through an HTTP probe URL and extracts Cloudflare trace fields. | Yes | Read before changing live validation, concurrency, accepted status behavior, trace parsing, or result semantics. |
+| `app/output/` | Writes deterministic TXT, CSV, and JSON artifact files. | Yes | Read before changing output writer behavior, file permissions, sorting, newline policy, or CSV/JSON serialization. |
+| `app/report/` | Defines JSON report and validated proxy record schema. | Yes | Read before changing report fields, JSON names, totals, or output schema compatibility. |
+| `app/pipeline/` | Orchestrates the full run and maps source/fetch/parse/validate output into artifacts and metadata. | Yes | Read before changing runtime flow, totals, per-source counts, CSV rows, or dependency injection. |
+| `configs/` | Versioned runtime defaults, especially `configs/sources.txt`. | Yes | Read before adding, removing, or reordering default upstream proxy source URLs. |
+| `docs/` | Human documentation and project policy notes. | No | Read the relevant doc before changing behavior it describes; do not create local rules here unless docs gain separate workflow constraints. |
+| `.github/` | Repository control plane: CODEOWNERS and GitHub Actions workflows. | Yes | Read before changing CODEOWNERS, permissions, workflow triggers, or automation policy. |
+| `.github/workflows/` | CI, build, and CD workflow definitions. | Yes | Read after `.github/AGENTS.md` before editing any workflow file. |
+| `.codex/` | Local workspace state if present. It is not project source. | No | Do not rely on it for repository behavior unless files are explicitly tracked and requested. |
+
+## On-demand cat protocol
+
+Before editing files under a directory that has a local `AGENTS.md`, read that file first.
+
+Examples:
+
+```bash
+cat app/AGENTS.md
+cat app/proxy/AGENTS.md
+```
+
+For `.github/workflows/`, read both:
+
+```bash
+cat .github/AGENTS.md
+cat .github/workflows/AGENTS.md
+```
+
+If a local card points to a specific doc, read that doc before editing behavior. For example, source-list work should read `docs/sources.md`, and report/CSV schema work should read `docs/result-fields.md`.
+
+## Commands
+
+| Command | Purpose | Scope | Sandbox notes |
+|---|---|---|---|
+| `go test ./...` | Run all Go package tests. | repo | OK in a normal local sandbox. |
+| `go vet ./...` | Static Go checks recommended by project docs. | repo | OK in a normal local sandbox. |
+| `go run . -h` | Print CLI help and verify flag registration. | root CLI | OK; no network expected. |
+| `go build -o bin/sky-socks5 .` | Build a local binary as shown in README. | root CLI | OK; writes `bin/`, do not commit binary artifacts. |
+| `go run . -output-dir generated` | Run the default source fetch, parse, validation, and artifact write flow. | root CLI | Requires external network and public proxies; writes `generated/`; do not use local reachability as CD evidence. |
+| `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o dist/sky-socks5 .` | Representative cross-build from the build workflow. | root CLI | OK; writes `dist/`, do not commit artifacts. |
+| `actionlint .github/workflows/*.yml` | Lint GitHub Actions workflow syntax. | `.github/workflows/` | Requires `actionlint` installed locally; not vendored by this repo. |
+
+## Global rules
+
+- Go version is defined by `go.mod`. Keep code compatible with that version unless the user asks for an upgrade.
+- Prefer Go standard library facilities. This module currently has no third-party dependencies; add dependencies only when the standard library is clearly insufficient.
+- `main.go` should remain a thin executable entrypoint. Put runtime behavior in `app/` packages.
+- Preserve package boundaries: config parses flags, source loads configured URLs, fetch downloads lists, proxy parses candidates, validate tests SOCKS5 reachability, output writes files, report defines schemas, pipeline orchestrates.
+- Keep outputs deterministic. Sorted text output, stable report ordering, and stable CSV columns matter for comparing runs.
+- Public proxy data is untrusted. Do not assume source metadata is truthful, and do not send sensitive traffic through discovered proxies.
+- Use `context.Context`, explicit timeouts, and bounded concurrency for network work.
+- For behavior changes, add or update tests in the nearest package. Existing tests are small and package-local; follow that style.
+- Run `gofmt` on changed `.go` files. Do not format unrelated files.
+- If changing source policy, read `docs/sources.md`. If changing output/report fields, read `docs/result-fields.md`. If changing package boundaries, read `docs/architecture.md`.
+
+## Do not
+
+- Do not commit generated artifacts from `generated/`, `dist/`, `bin/`, or ad hoc output directories.
+- Do not treat local SOCKS5 reachability results as proof of CD quality. CD validation intentionally runs in GitHub Actions.
+- Do not add release publishing behavior to the build workflow unless the user explicitly requests it.
+- Do not broaden GitHub Actions permissions from `contents: read` without a concrete reason and user-facing explanation.
+- Do not add scheduled or high-volume network validation jobs without explicit user approval.
+- Do not silently change CLI flag aliases such as `-proxy`, `-concurrency`, or `-meta-output`; they are compatibility surface.
+- Do not change CSV column names, JSON field names, or totals semantics without updating tests and the relevant docs.
+- Do not hardcode real production credentials. Short-lived test fixtures are acceptable only when they are explicitly harmless and scoped to tests.
+
+## Validation
+
+Default validation after Go code changes:
+
+1. `go test ./...`
+2. `go vet ./...`
+3. `go build -o bin/sky-socks5 .` when the CLI entrypoint, package exports, or build behavior changed.
+
+Additional targeted checks:
+
+- CLI flag or help changes: run `go run . -h` and the config tests through `go test ./app/config`.
+- Parser/source changes: run `go test ./app/proxy ./app/source ./app/pipeline`.
+- Output/report schema changes: run `go test ./app/output ./app/report ./app/pipeline` and compare `docs/result-fields.md`.
+- Workflow changes: run `actionlint .github/workflows/*.yml` if available, plus `go test ./...` for CI-related edits.
+- Default source-list changes: locally check fetchability, response format, and parser compatibility; do not claim local SOCKS5 reachability as CD evidence.
+- Full proxy validation with `go run . -output-dir generated` requires external network and public proxies, writes artifacts, and may be slow or flaky due to upstream conditions.
+
+For `AGENTS.md`-only changes, Go tests are not required unless you intentionally changed examples or command references. Confirm that only `AGENTS.md` files changed and that no `AGENTS.override.md` was created.
+
+## Notes for future agents
+
+- The runtime flow is documented in `docs/architecture.md`: `main.go -> app/pipeline -> app/config -> app/source -> app/fetch -> app/proxy -> app/validate -> app/output/app/report`.
+- `docs/sources.md` is the policy source for default upstream list changes.
+- `docs/result-fields.md` is the policy source for CSV and JSON report fields.
+- `.github/workflows/cd.yml` owns live proxy validation and generated artifact upload; local runs are development smoke checks.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,0 +1,28 @@
+# app navigation card
+
+`app/` contains the Go packages that implement the CLI runtime. Read this card before changing any package under `app/`; then read a deeper package card when one exists. Key files: `config/config.go`, `pipeline/pipeline.go`, `proxy/proxy.go`, `validate/validate.go`.
+
+## Local invariants
+
+- Runtime flow stays explicit: config parses flags, source loads URLs, fetch downloads source lists, proxy parses candidates, validate probes SOCKS5 reachability, output writes artifacts, report defines schemas, pipeline orchestrates.
+- Keep `main.go` thin. New runtime behavior belongs in an `app/` package, not in the executable entrypoint.
+- Network operations must accept context, timeout, and bounded-concurrency controls.
+- Outputs and reports must remain deterministic enough for repeated run comparison.
+- Tests should stay package-local and table-driven where possible.
+
+## Local rules
+
+- Read the package-specific `AGENTS.md` before changing a package that has one.
+- Use dependency injection already present in `app/pipeline` and `app/validate` instead of adding live network tests.
+- When changing report or CSV fields, read `docs/result-fields.md` before editing code.
+- When changing source parsing or default source expectations, read `docs/sources.md` before editing code.
+
+## Do not
+
+- Do not merge package responsibilities into a generic utility package without a clear caller-driven reason.
+- Do not add global mutable state for run configuration or result accumulation.
+- Do not make tests depend on live public proxies.
+
+## Validation
+
+Use root validation commands. For app-only code changes, `go test ./app/...` is the fastest focused check, followed by `go test ./...` before handoff.

--- a/app/config/AGENTS.md
+++ b/app/config/AGENTS.md
@@ -1,0 +1,29 @@
+# app/config navigation card
+
+`app/config` owns CLI flag parsing, defaults, aliases, URL validation, timeout/concurrency validation, and output path resolution. Read this card before changing any flag, default, alias, help text, or output path rule. Key files: `config.go`, `config_test.go`.
+
+## Local invariants
+
+- `DefaultSourceFile` is `configs/sources.txt`.
+- Default probe behavior is Cloudflare trace through `https://www.cloudflare.com/cdn-cgi/trace`.
+- Compatibility aliases are part of the CLI surface: `-proxy` for `-fetch-proxy`, `-concurrency` for `-validate-concurrency`, and `-meta-output` for `-report-output`.
+- All five output paths must resolve to distinct file paths: raw, unique, validated TXT, validated CSV, and JSON report.
+- Timeouts and validation concurrency must be greater than zero.
+- `-probe-url` must be HTTP or HTTPS; `-fetch-proxy` must be a supported proxy URL when provided.
+
+## Local rules
+
+- Update `Usage()` and tests in the same change when adding, renaming, or deleting a flag.
+- Keep path cleaning centralized through existing helpers unless a caller needs different semantics.
+- Preserve helpful error wrapping; pipeline surfaces these errors directly to CLI users.
+
+## Do not
+
+- Do not silently remove compatibility aliases.
+- Do not allow output files to collide; collisions can overwrite artifacts from the same run.
+- Do not add environment-variable configuration unless the user asks for it and tests cover precedence.
+
+## Validation
+
+- `go test ./app/config`
+- `go run . -h` after help text or flag registration changes.

--- a/app/fetch/AGENTS.md
+++ b/app/fetch/AGENTS.md
@@ -1,0 +1,27 @@
+# app/fetch navigation card
+
+`app/fetch` downloads upstream proxy source lists and records fetch metadata for reports. Read this card before changing HTTP request behavior, proxy support, timeout handling, response parsing, or fetch result ordering. Key files: `fetch.go`; callers live in `app/pipeline`.
+
+## Local invariants
+
+- Fetches run concurrently but results are sorted by source URL before returning.
+- The optional fetch proxy applies only to downloading source lists, not to SOCKS5 validation.
+- Only 2xx upstream HTTP status codes are treated as successful fetches.
+- Response bodies are parsed as trimmed non-empty lines with BOM prefixes removed.
+- Fetch errors are captured in `Result.Error` so pipeline can continue reporting per-source failures.
+
+## Local rules
+
+- Preserve context-aware requests.
+- Keep scanner limits intentional if response size handling changes.
+- Prefer adding focused tests before changing subtle network behavior; avoid live upstream tests in unit tests.
+
+## Do not
+
+- Do not make one failed source abort the entire aggregate fetch unless the user explicitly changes that product behavior.
+- Do not mix candidate parsing into this package; `app/proxy` owns proxy syntax.
+- Do not use local source fetch success as evidence that proxies are reachable.
+
+## Validation
+
+Use root validation commands. If adding tests here, keep them local and use `httptest` instead of public network endpoints.

--- a/app/output/AGENTS.md
+++ b/app/output/AGENTS.md
@@ -1,0 +1,27 @@
+# app/output navigation card
+
+`app/output` writes deterministic text, CSV, and JSON artifacts to disk. Read this card before changing file creation, sorting, deduplication, newline policy, CSV serialization, JSON formatting, or permissions. Key files: `output.go`; callers live in `app/pipeline`.
+
+## Local invariants
+
+- Text outputs trim blank lines, sort records, and end with a trailing newline when non-empty.
+- Deduplication is caller-selected; raw output can preserve duplicate observations while unique and validated outputs dedupe.
+- JSON output is indented with a trailing newline.
+- CSV output uses Go's `encoding/csv` writer.
+- Parent directories are created with `0755`, and files are written with `0644`.
+
+## Local rules
+
+- Keep write errors wrapped with enough path/context for CLI users.
+- Check pipeline tests when changing writer semantics; artifact content expectations usually live there.
+- If output paths or file names change, coordinate with `app/config`, `app/pipeline`, README, and docs.
+
+## Do not
+
+- Do not write outside the caller-resolved path.
+- Do not remove deterministic sorting without updating comparison and reporting expectations.
+- Do not swallow file-system errors.
+
+## Validation
+
+Use root validation commands. Add package tests if changing writer edge cases; run `go test ./app/output ./app/pipeline` for output behavior changes.

--- a/app/pipeline/AGENTS.md
+++ b/app/pipeline/AGENTS.md
@@ -1,0 +1,30 @@
+# app/pipeline navigation card
+
+`app/pipeline` orchestrates the full CLI run and converts source, fetch, parse, validation, output, and report data into user-facing artifacts. Read this card before changing runtime order, totals, per-source counts, CSV columns, dependency injection, or CLI summary output. Key files: `pipeline.go`, `pipeline_test.go`, `docs/result-fields.md`.
+
+## Local invariants
+
+- `RunCLI` parses config, calls `Run`, and prints one compact stdout summary.
+- `Run` must continue through per-source fetch and parse errors so reports can explain partial failures.
+- Raw, unique, validated TXT, validated CSV, and JSON report outputs are all written from one run.
+- Raw and unique proxy lists are sorted deterministically before validation/output.
+- Per-source `ValidProxies` is computed after global validation, counting a valid repeated proxy for every source that listed it.
+- CSV header order is an output contract and must stay aligned with `docs/result-fields.md`.
+
+## Local rules
+
+- Use `Dependencies` for tests instead of introducing live network or wall-clock dependencies.
+- When changing count semantics, update pipeline tests and CD summary assumptions.
+- When changing CSV/report fields, read `docs/result-fields.md` first and update `app/report` together.
+
+## Do not
+
+- Do not make one failed upstream source abort the entire aggregate run unless explicitly requested.
+- Do not write artifacts before all required in-memory metadata for the run is available.
+- Do not add new stdout formats without considering scripts that may parse the current summary.
+
+## Validation
+
+- `go test ./app/pipeline`
+- `go test ./app/report ./app/output ./app/pipeline` for artifact/schema changes.
+- `go test ./...` before handoff for runtime flow changes.

--- a/app/proxy/AGENTS.md
+++ b/app/proxy/AGENTS.md
@@ -1,0 +1,29 @@
+# app/proxy navigation card
+
+`app/proxy` owns SOCKS5 candidate parsing, normalization, validation, metadata extraction, and deterministic sorting. Read this card before changing accepted input formats, scheme rules, CSV-like metadata handling, IPv6 handling, or sort behavior. Key files: `proxy.go`, `proxy_test.go`, `docs/sources.md`.
+
+## Local invariants
+
+- Accepted candidate forms include `host:port`, `socks5://host:port`, `socks5://user:pass@host:port`, CSV-like `socks5://host:port,country,city`, and bracketed IPv6 with a port.
+- HTTP and HTTPS proxy records are not SOCKS5 candidates and must not be tested as SOCKS5.
+- Bare IPv6 addresses must use bracket notation.
+- Normalized addresses are `net.JoinHostPort(host, port)` with lower-cased hosts.
+- Blank lines and full-line comments are structural text, not parse errors.
+- Sorting must remain deterministic by host and numeric port.
+
+## Local rules
+
+- Add table-driven tests for every accepted or rejected input format change.
+- Keep source metadata extraction limited and explicit; the main CSV only consumes source country and city.
+- Check `docs/sources.md` when changing parsing assumptions for upstream source formats.
+
+## Do not
+
+- Do not add mixed-protocol support here by testing `http://` or `https://` records as SOCKS5.
+- Do not treat high upstream candidate counts as validation quality.
+- Do not change normalized output format without updating downstream tests and docs.
+
+## Validation
+
+- `go test ./app/proxy`
+- `go test ./app/pipeline` when normalized address, metadata, or sorting semantics affect reports.

--- a/app/report/AGENTS.md
+++ b/app/report/AGENTS.md
@@ -1,0 +1,28 @@
+# app/report navigation card
+
+`app/report` defines JSON report structures and validated proxy record fields. Read this card before changing JSON field names, totals, report shape, or validated proxy schema. Key files: `report.go`, `docs/result-fields.md`, `app/pipeline/pipeline.go`.
+
+## Local invariants
+
+- JSON field names are output contract, not internal-only implementation detail.
+- `Metadata.Finalize` sets UTC timestamps, run duration, invalid proxy totals, and stable source ordering.
+- `ValidatedProxy` must stay aligned with CSV row construction in `app/pipeline`.
+- Full Cloudflare trace maps remain in JSON while the CSV stays compact.
+- Per-source valid counts are restored after global deduplication, so repeated proxies count as valid for every source that listed them.
+
+## Local rules
+
+- Read `docs/result-fields.md` before schema changes.
+- Update pipeline tests and docs when adding, removing, or renaming report fields.
+- Keep optional JSON fields intentionally optional; avoid emitting noisy empty fields unless consumers need them.
+
+## Do not
+
+- Do not rename JSON tags casually.
+- Do not add Cloudflare diagnostic fields to top-level CSV/report records without a documented consumer need.
+- Do not change totals semantics without updating tests and workflow summaries.
+
+## Validation
+
+- `go test ./app/report ./app/pipeline`
+- Review `.github/workflows/cd.yml` summary generation if report fields consumed by CD change.

--- a/app/source/AGENTS.md
+++ b/app/source/AGENTS.md
@@ -1,0 +1,26 @@
+# app/source navigation card
+
+`app/source` loads configured upstream source URLs from a local text file. Read this card before changing source-file parsing, empty-file behavior, BOM handling, or comment handling. Key files: `source.go`, `source_test.go`, `configs/sources.txt`.
+
+## Local invariants
+
+- Non-empty, non-comment lines are source URLs.
+- Full-line `#` comments and blank lines are skipped.
+- UTF-8 BOM prefixes should not break the first line.
+- Empty effective source files must return an error.
+- This package does not fetch URLs and does not validate whether a URL returns SOCKS5 candidates.
+
+## Local rules
+
+- Keep this package focused on local file parsing. Fetchability belongs to `app/fetch`; candidate parsing belongs to `app/proxy`.
+- If accepted source-file syntax changes, update tests and check whether `docs/sources.md` needs a matching change.
+
+## Do not
+
+- Do not make source loading perform network requests.
+- Do not silently accept an empty source set as a successful run.
+
+## Validation
+
+- `go test ./app/source`
+- Run `go test ./...` before handoff when behavior affects pipeline startup.

--- a/app/validate/AGENTS.md
+++ b/app/validate/AGENTS.md
@@ -1,0 +1,28 @@
+# app/validate navigation card
+
+`app/validate` tests deduplicated SOCKS5 proxies through an HTTP probe URL and extracts compact Cloudflare trace evidence. Read this card before changing live validation, concurrency, accepted status handling, trace parsing, or result fields. Key files: `validate.go`, `validate_test.go`, `docs/result-fields.md`.
+
+## Local invariants
+
+- Validation uses `socks5://<address>` as the HTTP client proxy.
+- `ProbeURL`, positive `Timeout`, positive `Concurrency`, and non-empty `ValidStatuses` are required.
+- A proxy is reachable only when the probe request completes and returns an accepted HTTP status.
+- Cloudflare trace is parsed as `key=value` lines; CSV-facing fields are limited to compact evidence such as exit IP, country, colo, HTTP, and non-default flags.
+- Full raw trace data belongs in the JSON report, not expanded blindly into CSV columns.
+
+## Local rules
+
+- Keep validation context-aware and bounded by caller-provided timeout/concurrency.
+- Use the `Probe` hook or small parser tests for unit coverage; do not require live public proxies in tests.
+- Read `docs/result-fields.md` before adding or removing trace-derived fields.
+
+## Do not
+
+- Do not present local validation output as CD-quality evidence.
+- Do not add ASN, ISP, city, region, or risk-score fields from Cloudflare trace; the docs state Cloudflare trace does not provide them.
+- Do not make validation fail the whole run because one proxy is unreachable.
+
+## Validation
+
+- `go test ./app/validate`
+- `go test ./app/pipeline` when result semantics feed CSV or JSON outputs.

--- a/configs/AGENTS.md
+++ b/configs/AGENTS.md
@@ -1,0 +1,29 @@
+# configs navigation card
+
+`configs/` stores versioned runtime defaults, especially `configs/sources.txt`, the default aggregate upstream source list. Read this card before adding, removing, reordering, or replacing source URLs. Key files: `sources.txt`, `docs/sources.md`, `.github/workflows/cd.yml`.
+
+## Why this is high-risk
+
+- Default sources drive the CD proxy validation workload.
+- Large or mixed-protocol feeds can inflate candidate counts without improving valid SOCKS5 output.
+- Local network results can differ materially from GitHub Actions network results.
+
+## Required before changes
+
+- Read `docs/sources.md` for current source policy.
+- Prefer SOCKS5-specific HTTP/HTTPS text endpoints.
+- Keep additions small and reviewable.
+- Locally check source fetchability, returned format, and parser compatibility when practical.
+- Use CD per-source results, not local reachability, before promoting large or uncertain feeds into the default aggregate list.
+
+## Do not
+
+- Do not add meta-source URL lists that require nested-source support unless code support is added first.
+- Do not add very large mixed-protocol feeds by default without evidence they contribute useful unique and valid SOCKS5 proxies.
+- Do not keep sources that consistently return hard HTTP errors such as 404 or 502.
+- Do not commit generated output from source-list experiments.
+
+## Validation
+
+- `go test ./app/source ./app/proxy ./app/pipeline`
+- Full `go run . -output-dir generated` requires network and public proxies; treat it as a development smoke run, not CD proof.


### PR DESCRIPTION
## Summary

- Add a root `AGENTS.md` router for Codex startup behavior, directory map, command index, global rules, and validation guidance.
- Add package-level navigation cards under `app/` for config, source, fetch, proxy, validate, output, report, and pipeline responsibilities.
- Add guardrail cards for `configs/`, `.github/`, and `.github/workflows/` to protect source-list and automation changes.

## Validation

- `git diff --cached --check` before commit
- `go test ./...`

## Scope

- Only `AGENTS.md` files are added.
- No Go source, README, config, workflow, or generated artifact files are changed.